### PR TITLE
修复PDF懒加载判断错误导致渲染多余不存在canvas问题

### DIFF
--- a/core/packages/vue-pdf/src/main.vue
+++ b/core/packages/vue-pdf/src/main.vue
@@ -78,11 +78,14 @@ export default defineComponent({
         function onScrollPdf(e) {
             const { scrollTop, scrollHeight, clientHeight } = e.target;
             if (scrollTop + clientHeight >= scrollHeight) {
-                if (numPages.value < pdfDocument.numPages) {
-                    let oldNum = numPages.value;
-                    numPages.value += Math.min(lazySize, pdfDocument.numPages);
-                    renderPage(oldNum+1);
-                }
+              if (numPages.value >= pdfDocument.numPages) {
+                return;
+              }
+              let oldNum = numPages.value;
+              numPages.value = Math.min(pdfDocument.numPages, oldNum + lazySize);
+              if (numPages.value > oldNum) {
+                renderPage(oldNum + 1);
+              }
             }
         }
 


### PR DESCRIPTION
fix: 修复PDF组件在PDF页面超过默认懒加载页数时。在滚动页面时，由于判断错误，导致计算numPages 值比实际页数大，且未经判断，直接渲染新页面，使得渲染后的页面出现了什么都没有canvas